### PR TITLE
Adding ability to load config from /etc/jabber-tee.yml

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,10 @@ The command line tool can be installed with:
 The general idea is that you can pipe anything from the console into this, and it will be sent to the remote jabber server:
 
     cat huge_text_file.txt | jabber-tee -u peon@bigcorp.com --room working-hard@rooms.bigcorp.com --nick 'Worker Drone'
-  
+
+or
+    echo "I am $(whoami) at $(hostname)" | jabber-tee -to somebody@somewhere.com
+
 # Configuration
 
 Because entering the same information on the command line for this thing can be tedious, you can create a ~/.jabber-tee.yml file that fills in all of the basic configuration.  This file also allows you to further customize the output that is sent to the jabber server.
@@ -24,7 +27,7 @@ An example configuration file:
     username: my.name@jabber.org
     nick: 'Gabe'
 
-    # Individual profiles that customize global variables    
+    # Individual profiles that customize global variables
     profiles:
         new-hotness:
             # Uses the standard username, above
@@ -35,6 +38,7 @@ An example configuration file:
             username: supercooldude@gmail.com
             nick: 'Rocksteady Gabe'
             to: somebody.else@gmail.com
+            password: secret
 
         work-stuff:
             username: peon@bigcorp.com

--- a/lib/jabber-tee/cli.rb
+++ b/lib/jabber-tee/cli.rb
@@ -67,7 +67,8 @@ DESC
                 "The password for the user to connect",
                 "to the jabber server.  If not given",
                 "it must be defined in your",
-                "~/.jabber-tee.yml file.") do |p|
+                "~/.jabber-tee.yml or",
+                "/etc/jabber-tee.yml file.") do |p|
           options[:password] = p
         end
         opts.on('-n', '--nick NICKNAME',
@@ -84,8 +85,8 @@ DESC
 =end
         opts.on('-P', '--profile PROFILE',
                 "The name of the profile, as defined in",
-                "the ~/.jabber-tee.yml file to use to",
-                "connect with.") do |p|
+                "the ~/.jabber-tee.yml or /etc/jabber-tee.yml",
+                "file to use to connect with.") do |p|
           options[:profile] = p
         end
 =begin
@@ -110,7 +111,7 @@ DESC
         end
         opts.on('-r', '--room ROOM',
                 "The room to send the messages to.") do |r|
-          options[:room] = r 
+          options[:room] = r
         end
         opts.separator ""
 
@@ -143,13 +144,22 @@ DESC
       exit 1
     end
 
-    JABBER_FILE = '.jabber-tee.yml'
+    # TODO: Does 'home' work for Windows users?
+    JABBER_FILE_LOCATIONS = [
+      File.join(ENV["HOME"], ".jabber-tee.yml"),
+      "/etc/jabber-tee.yml"
+    ]
 
     def load_configuration
-      home = ENV['HOME'] # TODO: Windows users?
-      config_file = File.join(home, JABBER_FILE)
+      config_file = nil
+      JABBER_FILE_LOCATIONS.each do |location|
+        if File.exists?(location)
+          config_file = location
+          break
+        end
+      end
 
-      if File.exists?(config_file)
+      if config_file
         reader = ConfigurationReader.new(config_file)
         if options.has_key?(:profile)
           reader.profile(options[:profile]).merge(options)


### PR DESCRIPTION
Hey Gabemc,

I found this on rubygems, and seemed pretty close to what I am looking for.  I added a fix to be able to load a config from from /etc/jammer-tee.yml (it still prefers ~/.jammer-tee.yml).  I also added a tweak to the readme, to make it clear how to specify passwords and the --to syntax.  Thanks, -nick
